### PR TITLE
Handle command line arguments

### DIFF
--- a/kneesocks
+++ b/kneesocks
@@ -15,4 +15,4 @@ EOF
 fi
 
 export LD_PRELOAD="libkneesocks.so $LD_PRELOAD"
-exec $*
+exec "$*"


### PR DESCRIPTION
Passed command-line arguments including spaces ` ` will be passed as separated arguments.

```console
kneesocks psql "host=example.com port=5432"
```

is now dealt as

```console
# should be psql "host=example.com port=5432"
psql "host=example.com" "port=5432"
```

This PR fixes the issue.